### PR TITLE
fixed usage of random (max is exclusive)

### DIFF
--- a/examples/Fletcher16_performance/Fletcher16_performance.ino
+++ b/examples/Fletcher16_performance/Fletcher16_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher32_performance/Fletcher32_performance.ino
+++ b/examples/Fletcher32_performance/Fletcher32_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher64_performance/Fletcher64_performance.ino
+++ b/examples/Fletcher64_performance/Fletcher64_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher_random_stream_performance/Fletcher_random_stream_performance.ino
+++ b/examples/Fletcher_random_stream_performance/Fletcher_random_stream_performance.ino
@@ -1,0 +1,150 @@
+/*
+  Author: Daniel Mohr
+  Date: 2022-09-07
+  Purpose: shows stream performance
+*/
+#include "Arduino.h"
+
+#include "printHelpers.h" // needed for Arduino Nano
+#include <Fletcher16.h>
+#include <Fletcher32.h>
+#include <Fletcher64.h>
+
+#ifdef ARDUINO_ARCH_AVR
+#define MAX_LEN 1024
+#else
+#define MAX_LEN 16384
+#endif
+
+#define DO_N 23
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial);
+}
+
+void test_fletcher16() {
+  Serial.println("Fletcher16");
+  const uint16_t max_len = MAX_LEN;
+  uint8_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = (uint8_t) random(0, 1 << 8);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher16 checksum_instance;
+  uint16_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(checksum);
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void test_fletcher32() {
+  Serial.println("Fletcher32");
+  const uint16_t max_len = MAX_LEN / 2;
+  uint16_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = (uint16_t) random(0, ((uint32_t) 1) << 16);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher32 checksum_instance;
+  uint32_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(checksum);
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void test_fletcher64() {
+  Serial.println("Fletcher64");
+  const uint16_t max_len = MAX_LEN / 4;
+  uint32_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = ((uint32_t) random(0, ((uint32_t) 1) << 16)) + (((uint32_t) random(0, ((uint32_t) 1) << 16)) << 16);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher64 checksum_instance;
+  uint64_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(print64(checksum));
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void loop() {
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN);
+  Serial.println(" elements for Fletcher16");
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN/2);
+  Serial.println(" elements for Fletcher32");
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN/4);
+  Serial.println(" elements for Fletcher64");
+  Serial.println("");
+  test_fletcher16();
+  Serial.println("");
+  delay(1000);
+  test_fletcher32();
+  Serial.println("");
+  delay(1000);
+  test_fletcher64();
+  Serial.println("");
+  delay(1000);
+  Serial.println("");
+}


### PR DESCRIPTION
Documentation of [random](https://www.arduino.cc/reference/en/language/functions/random-numbers/random/) says the upper bound of the random value is exclusive. Therefore adapted the usage here.

Further in [Fletcher32_performance.ino](https://github.com/RobTillaart/Fletcher/blob/master/examples/Fletcher32_performance/Fletcher32_performance.ino) `z` could be `uint16_t` instead of `uint8_t` and the random value could then also be 16 bit.

Similar in [Fletcher64_performance.ino](https://github.com/RobTillaart/Fletcher/blob/master/examples/Fletcher64_performance/Fletcher64_performance.ino) could be used `uint32_t` instead of `uint8_t`.

If you are interested, I would also provide this small enhancement in this small merge request.