### PR TITLE
Performance

### DIFF
--- a/Fletcher16.cpp
+++ b/Fletcher16.cpp
@@ -28,9 +28,9 @@ void Fletcher16::add(uint8_t value)
 {
   _count++;
   _s1 += value;
-   if (_s1 >= FLETCHER_16) _s1 -= FLETCHER_16;
+  _s1 = (_s1 & ((1<<8)-1)) + (_s1 >> 8);
   _s2 += _s1;
-   if (_s2 >= FLETCHER_16) _s2 -= FLETCHER_16;
+  _s2 = (_s2 & ((1<<8)-1)) + (_s2 >> 8);
 }
 
 

--- a/Fletcher32.cpp
+++ b/Fletcher32.cpp
@@ -29,9 +29,17 @@ void Fletcher32::add(uint16_t value)
 {
   _count++;
   _s1 += value;
-   if (_s1 >= FLETCHER_32) _s1 -= FLETCHER_32;
+#ifdef ARDUINO_ARCH_SAMD
+  _s1 = (_s1 & 65535UL) + (_s1 >> 16);
+#else
+  if (_s1 >= FLETCHER_32) _s1 -= FLETCHER_32;
+#endif
   _s2 += _s1;
-   if (_s2 >= FLETCHER_32) _s2 -= FLETCHER_32;
+#ifdef ARDUINO_ARCH_SAMD
+  _s2 = (_s2 & 65535UL) + (_s2 >> 16);
+#else
+  if (_s2 >= FLETCHER_32) _s2 -= FLETCHER_32;
+#endif
 }
 
 //  NOTE: padding with zero's error

--- a/Fletcher64.cpp
+++ b/Fletcher64.cpp
@@ -29,9 +29,17 @@ void Fletcher64::add(uint32_t value)
 {
   _count++;
   _s1 += value;
-   if (_s1 >= FLETCHER_64) _s1 -= FLETCHER_64;
+#ifdef ARDUINO_ARCH_SAMD
+  _s1 = (_s1 & ((((uint64_t) 1)<<32)-1)) + (_s1 >> 32);
+#else
+  if (_s1 >= FLETCHER_64) _s1 -= FLETCHER_64;
+#endif
   _s2 += _s1;
-   if (_s2 >= FLETCHER_64) _s2 -= FLETCHER_64;
+#ifdef ARDUINO_ARCH_SAMD
+  _s2 = (_s2 & ((((uint64_t) 1)<<32)-1)) + (_s2 >> 32);
+#else
+  if (_s2 >= FLETCHER_64) _s2 -= FLETCHER_64;
+#endif
 }
 
 

--- a/examples/Fletcher16_performance/Fletcher16_performance.ino
+++ b/examples/Fletcher16_performance/Fletcher16_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher32_performance/Fletcher32_performance.ino
+++ b/examples/Fletcher32_performance/Fletcher32_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher64_performance/Fletcher64_performance.ino
+++ b/examples/Fletcher64_performance/Fletcher64_performance.ino
@@ -24,7 +24,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
   }
   stop = micros();
   randomtime = stop - start;
@@ -36,7 +36,7 @@ void setup()
   start = micros();
   for (uint16_t x = 0; x < 10000; x++)
   {
-    z = random(255);
+    z = random(256);
     fl.add(z);
   }
   stop = micros();

--- a/examples/Fletcher_random_stream_performance/Fletcher_random_stream_performance.ino
+++ b/examples/Fletcher_random_stream_performance/Fletcher_random_stream_performance.ino
@@ -1,0 +1,150 @@
+/*
+  Author: Daniel Mohr
+  Date: 2022-09-07
+  Purpose: shows stream performance
+*/
+#include "Arduino.h"
+
+#include "printHelpers.h" // needed for Arduino Nano
+#include <Fletcher16.h>
+#include <Fletcher32.h>
+#include <Fletcher64.h>
+
+#ifdef ARDUINO_ARCH_AVR
+#define MAX_LEN 1024
+#else
+#define MAX_LEN 16384
+#endif
+
+#define DO_N 23
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial);
+}
+
+void test_fletcher16() {
+  Serial.println("Fletcher16");
+  const uint16_t max_len = MAX_LEN;
+  uint8_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = (uint8_t) random(0, 1 << 8);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher16 checksum_instance;
+  uint16_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(checksum);
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void test_fletcher32() {
+  Serial.println("Fletcher32");
+  const uint16_t max_len = MAX_LEN / 2;
+  uint16_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = (uint16_t) random(0, ((uint32_t) 1) << 16);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher32 checksum_instance;
+  uint32_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(checksum);
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void test_fletcher64() {
+  Serial.println("Fletcher64");
+  const uint16_t max_len = MAX_LEN / 4;
+  uint32_t values[max_len];
+  uint32_t t0, t1;
+  delay(100);
+  t0 = micros();
+  for (uint16_t i = 0; i < max_len; i++) {
+    values[i] = ((uint32_t) random(0, ((uint32_t) 1) << 16)) + (((uint32_t) random(0, ((uint32_t) 1) << 16)) << 16);
+  }
+  t1 = micros();
+  Serial.print("Created random list: ");
+  Serial.print(1024.0 * (t1 - t0) / float(MAX_LEN));
+  Serial.println(" us/kByte.");
+  Fletcher64 checksum_instance;
+  uint64_t checksum;
+  uint32_t totaltime = 0;
+  for (uint16_t j = 0; j < DO_N; j++) {
+    t0 = micros();
+    checksum_instance.begin();
+    for (uint16_t i = 0; i < max_len; i++) {
+      checksum_instance.add(values[i]);
+    }
+    checksum = checksum_instance.getFletcher();
+    t1 = micros();
+    totaltime += t1 - t0;
+  }
+  Serial.print("Checksum: ");
+  Serial.println(print64(checksum));
+  Serial.print("Created checksum: ");
+  Serial.print(1024.0 * totaltime / float(DO_N * MAX_LEN));
+  Serial.println(" us/kByte.");
+}
+
+void loop() {
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN);
+  Serial.println(" elements for Fletcher16");
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN/2);
+  Serial.println(" elements for Fletcher32");
+  Serial.print("Using list of ");
+  Serial.print(MAX_LEN/4);
+  Serial.println(" elements for Fletcher64");
+  Serial.println("");
+  test_fletcher16();
+  Serial.println("");
+  delay(1000);
+  test_fletcher32();
+  Serial.println("");
+  delay(1000);
+  test_fletcher64();
+  Serial.println("");
+  delay(1000);
+  Serial.println("");
+}


### PR DESCRIPTION
Since #6 gives a test of all Fletcher implementations here, I also investigated quickly the ideas written on [wikipedia:Fletcher's checksum](https://en.wikipedia.org/wiki/Fletcher%27s_checksum).

Using bit shifts instead of the if statement could speed up the things:

Data rate on Arduino Nano (ATmega 328P):
| alg | if statement | bit shifts |
| --- | --- | --- |
| Fletcher16 | 1333.04 us/kByte | 1301.39 us/kByte |
| Fletcher32 | 1106.78 us/kByte | 1302.26 us/kByte |
| Fletcher64 | 3791.83 us/kByte | 6408.00 us/kByte |

Data rate on Arduino MKRZERO (SAMD21):
| alg | if statement | bit shifts |
| --- | --- | --- |
| Fletcher16 | 1011.79 us/kByte | 968.48 us/kByte |
| Fletcher32 | 597.56 us/kByte | 505.77 us/kByte |
| Fletcher64 | 436.85 us/kByte | 425.15 us/kByte |

I believe that for 8 Bit (Fletcher16) it's always the same. Therefore I adapted your code here.

For more than 8 Bit (Fletcher32 or Fletcher64) I believe it depends on the platform. Therefore I adapted your code only for SAMD21, which I could test. This could be enhanced for all 16 Bit or 32 Bit systems.

I hope this PR is OK?